### PR TITLE
Updates checkinvariant to version 1.0

### DIFF
--- a/ados/General/checkinvariant/LICENSE
+++ b/ados/General/checkinvariant/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Luís Fonseca
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ados/General/checkinvariant/README.md
+++ b/ados/General/checkinvariant/README.md
@@ -6,7 +6,9 @@ This command checks whether a given variable is constant or varies within the un
 
 To install run the following in Stata:
 
+```
 net install checkinvariant, from("https://github.com/BPLIM/Tools/raw/master/ados/General/checkinvariant")
+```
 
 ## Author
 

--- a/ados/General/checkinvariant/checkinvariant.ado
+++ b/ados/General/checkinvariant/checkinvariant.ado
@@ -1,9 +1,9 @@
+*! version 1.0 10sep2019 Luís Fonseca, https://github.com/luispfonseca
 *! -checkinvariant- Check if a variable is invariant within a group
-*! Luís Fonseca, https://github.com/luispfonseca
 
 program define checkinvariant, rclass
 
-syntax varlist, by(varlist) [ALLOWMISSing fill DROPINVARiant DROPVARiant KEEPINVARiant KEEPVARiant VERBose]
+syntax [varlist], [by(varlist) ALLOWMISSing fill DROPINVARiant DROPVARiant KEEPINVARiant KEEPVARiant VERBose]
 
 if "`allowmissing'" == "" & "`fill'" != "" {
 	di as error "The fill option can only be called with the allowmissing option."
@@ -22,6 +22,15 @@ local keepcondition "`keepvariant'`keepinvariant'"
 if "`dropcondition'" != "" & "`keepcondition'" != "" {
 	di as error "Choose only one condition between keep and drop."
 	error 198
+}
+
+* if no varlist is passed, assume all variables are passed
+if "`varlist'" == "" {
+	local varlist _all
+}
+* display " within by_variables" only if by is not empty
+if "`by'" != "" {
+	local within_string " within "
 }
 
 * ensure no duplicates in the varlist to loop over
@@ -58,7 +67,7 @@ foreach var in `varlist' {
 
 	if c(rc) == 0 {
 		if "`verbose'" != "" {
-			di as result "Invariant within `by': `var'"
+			di as result "Invariant`within_string'`by': `var'"
 		}
 		local invariantvarlist `invariantvarlist' `var'
 		if "`fill'" != "" & "`allowmissing'" != "" {
@@ -80,7 +89,7 @@ foreach var in `varlist' {
 	}
 	else {
 		if "`verbose'" != "" {
-			di as result "  Variant within `by': `var'"
+			di as result "  Variant`within_string'`by': `var'"
 		}
 		local   variantvarlist   `variantvarlist' `var'
 	}
@@ -89,22 +98,16 @@ foreach var in `varlist' {
 qui hashsort `originalsort'
 
 if "`invariantvarlist'" != "" {
-	di as result "Invariant within `by':"
-	foreach var in `invariantvarlist' {
-		di as result "`var'"
-	}
+	di as result "Invariant`within_string'`by':"
+	di as result "`invariantvarlist'"
 }
 if "`variantvarlist'" != "" {
-	di as result "Variant within `by':"
-	foreach var in `variantvarlist' {
-		di as result "`var'"
-	}
+	di as result "Variant`within_string'`by':"
+	di as result "`variantvarlist'"
 }
 if "`filledvarlist'" != "" {
 	di as result "Variables whose missing values were replaced by unique non-missing value:"
-	foreach var in `filledvarlist' {
-		di as result "`var'"
-	}
+	di as result "`filledvarlist'"
 }
 
 return local varlist = "`varlist'"
@@ -122,34 +125,29 @@ if "`fill'" != "" & "`allowmissing'" != "" {
 
 if "`dropinvariant'" != "" {
 	if "`invariantvarlist'" != "" {
-		di as result "Dropping invariant variables:"
-		di as result "`invariantvarlist'"
+		di as result "Dropping invariant variables"
 		local todrop `invariantvarlist'
 	}
 	if "`filledvarlist'" != "" {
-		di as result "Dropping filled variables:"
-		di as result "`filledvarlist'"
+		di as result "Dropping filled variables"
 		local todrop `todrop' `filledvarlist'
 	}
 	cap drop `todrop'
 }
 if "`dropvariant'" != "" {
 	if "`variantvarlist'" != "" {
-		di as result "Dropping variant variables:"
-		di as result "`variantvarlist'"
+		di as result "Dropping variant variables"
 		drop `variantvarlist'
 	}
 }
 
 if "`keepinvariant'" != "" {
 	if "`invariantvarlist'" != "" {
-		di as result "Keeping invariant variables:"
-		di as result "`invariantvarlist'"
+		di as result "Keeping invariant variables"
 		local tokeep `invariantvarlist'
 	}
 	if "`filledvarlist'" != "" {
-		di as result "Keeping filled variables:"
-		di as result "`filledvarlist'"
+		di as result "Keeping filled variables"
 		local tokeep `tokeep' `filledvarlist'
 	}
 	local tokeep `by' `tokeep'
@@ -157,8 +155,7 @@ if "`keepinvariant'" != "" {
 }
 if "`keepvariant'" != "" {
 	if "`variantvarlist'" != "" {
-		di as result "Keeping variant variables:"
-		di as result "`variantvarlist'"
+		di as result "Keeping variant variables"
 		local tokeep `variantvarlist'
 	}
 	local tokeep `by' `tokeep'

--- a/ados/General/checkinvariant/checkinvariant.pkg
+++ b/ados/General/checkinvariant/checkinvariant.pkg
@@ -1,4 +1,8 @@
+v 1.0
 d 'CHECKINVARIANT': checkinvariant
 d
+d Distribution-Date:   20190910
+d License: MIT
+
 F checkinvariant.ado
 F checkinvariant.sthlp

--- a/ados/General/checkinvariant/checkinvariant.sthlp
+++ b/ados/General/checkinvariant/checkinvariant.sthlp
@@ -1,9 +1,13 @@
 {smcl}
+{* *! version 1.0  10sep2019}{...}
 {findalias asfradohelp}{...}
 {vieweralsosee "" "--"}{...}
 {vieweralsosee "[R] help" "help help"}{...}
 {viewerjumpto "Syntax" "checkinvariant##syntax"}{...}
 {viewerjumpto "Description" "checkinvariant##description"}{...}
+{viewerjumpto "Examples" "checkinvariant##examples"}{...}
+{viewerjumpto "Author" "checkinvariant##author"}{...}
+{viewerjumpto "Website" "checkinvariant##website"}{...}
 {title:Title}
 
 {phang}
@@ -13,13 +17,13 @@
 {title:Syntax}
 
 {p 8 15 2}
-{opt checkinvariant} {it:varlist} , by({it:varlist}) [{it:options}]
+{opt checkinvariant} [{it:varlist} , by({it:varlist}) {it:options}]
 
 {synoptset 20 tabbed}{...}
 {synopthdr}
 {synoptline}
 {synopt:{opt allowmiss:ing}}Consider as invariant the case where a variable has missing values and a unique non-missing value within each group{p_end}
-{synopt:{opt fill}}For the case in allowmissing, replace the missing values with the unique non-missing value within each group{p_end}
+{synopt:{opt fill}}Replaces missing values with the unique non-missing value within each group. Requires {opt allowmiss:ing}{p_end}
 {synopt:{opt dropinvar:iant}}Drops the invariant variables (including the filled ones when fill is called){p_end}
 {synopt:{opt dropvar:iant}}Drops the variant variables{p_end}
 {synopt:{opt keepinvar:iant}}Keeps the invariant variables (including the filled ones when filled is called) and the {it:by} variables{p_end}
@@ -33,14 +37,28 @@
 
 {pstd}This command checks whether a given variable is constant or varies within the unique values of another group of variables. It is useful to ensure that panel datasets are coherent (e.g. attributes that should be constant within unit or time period indeed are).
 
+{pstd}The command also returns scalars and macros with the number and lists of variant and invariant variables that can be used in subsequent commands.
+
 {pstd}The only dependency of this command is gtools, by Mauricio Caceres, about which you can find at {browse "https://github.com/mcaceresb/stata-gtools"}.
 
+{pstd}In the repository where the {cmd:checkinvariant} is maintained, you can find a file with tests for the command that should verify that it is working properly. This can be particularly useful if you intend to make extensions to the command.
+
+{marker examples}{...}
+{title:Examples}
+
+sysuse auto, clear
+gen brand = make
+replace brand = regexr(brand, " .*", "")
+checkinvariant, by(brand)
+
+{marker author}{...}
 {title:Author}
 
 {pstd}Luís Fonseca, London Business School.
 
 {pstd}Website: {browse "https://luispfonseca.com"}
 
+{marker website}{...}
 {title:Website}
 
 {pstd}{cmd:checkinvariant} is maintained at {browse "https://github.com/luispfonseca/stata-misc"}{p_end}

--- a/ados/General/checkinvariant/checkinvariant_tests.do
+++ b/ados/General/checkinvariant/checkinvariant_tests.do
@@ -1,6 +1,8 @@
 cap program drop checkinvariant
 qui do checkinvariant.ado
 
+** NEED TO WRITE TESTS ON EMPTY ARGUMENTS FOR VARLIST and by() **
+
 set varabbrev off
 
 clear

--- a/ados/General/checkinvariant/stata.toc
+++ b/ados/General/checkinvariant/stata.toc
@@ -1,2 +1,1 @@
 p checkinvariant	Check if a variable is invariant within a group
-p propagate			Fill missing values with the unique non-missing value within a group


### PR DESCRIPTION
Plus some small additional fixes to stata.toc and README.md and adding of license

--

The command did not have a numeric version before. This commit adds a numeric version, which can aid reproducibility.

In addition, some small improvements to the command (not required to pass a specific varlist as it will assume _all if none is passed; less verbose) and the help file (more detail, examples)